### PR TITLE
fix: 修复windows下因路径问题导致无法创建文件夹

### DIFF
--- a/src/tars2php.php
+++ b/src/tars2php.php
@@ -329,6 +329,8 @@ class FileConverter
     public function initDir()
     {
         if (strtolower(substr(php_uname('a'), 0, 3)) === 'win') {
+            $this->outputDir = str_replace('/', '\\', $this->outputDir);
+            $this->fromFile = str_replace('/', '\\', $this->fromFile);
             exec('mkdir '.$this->outputDir.$this->appName);
             exec('mkdir '.$this->outputDir.$this->appName.'\\'.$this->serverName);
             exec('DEL '.$this->outputDir.$this->appName.'\\'.$this->serverName.'\\'.$this->objName.'\\*.*');


### PR DESCRIPTION
在window下无法使用
`php ./tars2php.php tars.proto.php`
命令